### PR TITLE
Add Claude Sonnet 5 support and fix ChatAnthropic API compatibility.

### DIFF
--- a/packages/components/models.json
+++ b/packages/components/models.json
@@ -4,6 +4,13 @@
             "name": "awsChatBedrock",
             "models": [
                 {
+                    "label": "anthropic.claude-sonnet-5",
+                    "name": "anthropic.claude-sonnet-5",
+                    "description": "Claude Sonnet 5",
+                    "input_cost": 0.000002,
+                    "output_cost": 0.00001
+                },
+                {
                     "label": "anthropic.claude-opus-4-5-20251101-v1:0",
                     "name": "anthropic.claude-opus-4-5-20251101-v1:0",
                     "description": "Claude 4.5 Opus",
@@ -513,6 +520,13 @@
             "name": "chatAnthropic",
             "models": [
                 {
+                    "label": "claude-sonnet-5",
+                    "name": "claude-sonnet-5",
+                    "description": "Claude Sonnet 5",
+                    "input_cost": 0.000002,
+                    "output_cost": 0.00001
+                },
+                {
                     "label": "claude-opus-4-8",
                     "name": "claude-opus-4-8",
                     "description": "Claude 4.8 Opus",
@@ -834,6 +848,13 @@
                     "description": "Claude 4.8 Opus",
                     "input_cost": 0.000005,
                     "output_cost": 0.000025
+                },
+                {
+                    "label": "claude-sonnet-5",
+                    "name": "claude-sonnet-5",
+                    "description": "Claude Sonnet 5",
+                    "input_cost": 0.000002,
+                    "output_cost": 0.00001
                 },
                 {
                     "label": "claude-opus-4-5@20251101",

--- a/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
@@ -4,6 +4,7 @@ import { BaseLLMParams } from '@langchain/core/language_models/llms'
 import { ICommonObject, IMultiModalOption, INode, INodeData, INodeOptionsValue, INodeParams } from '../../../src/Interface'
 import { getBaseClasses, getCredentialData, getCredentialParam } from '../../../src/utils'
 import { ChatAnthropic as FlowiseChatAnthropic } from './FlowiseChatAnthropic'
+import { buildThinkingConfig, rejectsSamplingParams } from './anthropicModelCompat'
 import { getModels, MODEL_TYPE } from '../../../src/modelLoader'
 
 class ChatAnthropic_ChatModels implements INode {
@@ -21,7 +22,7 @@ class ChatAnthropic_ChatModels implements INode {
     constructor() {
         this.label = 'ChatAnthropic'
         this.name = 'chatAnthropic'
-        this.version = 9.2
+        this.version = 9.3
         this.type = 'ChatAnthropic'
         this.icon = 'Anthropic.svg'
         this.category = 'Chat Models'
@@ -53,6 +54,8 @@ class ChatAnthropic_ChatModels implements INode {
                 type: 'number',
                 step: 0.1,
                 default: 0.9,
+                description:
+                    'Not supported on Claude Sonnet 5 and Opus 4.7+ (sampling parameters are omitted for those models).',
                 optional: true
             },
             {
@@ -76,6 +79,7 @@ class ChatAnthropic_ChatModels implements INode {
                 name: 'topP',
                 type: 'number',
                 step: 0.1,
+                description: 'Not supported on Claude Sonnet 5 and Opus 4.7+.',
                 optional: true,
                 additionalParams: true
             },
@@ -84,6 +88,7 @@ class ChatAnthropic_ChatModels implements INode {
                 name: 'topK',
                 type: 'number',
                 step: 0.1,
+                description: 'Not supported on Claude Sonnet 5 and Opus 4.7+.',
                 optional: true,
                 additionalParams: true
             },
@@ -92,7 +97,7 @@ class ChatAnthropic_ChatModels implements INode {
                 name: 'extendedThinking',
                 type: 'boolean',
                 description:
-                    'Turn on to stream Claude internal thinking separately from the answer (SSE event name: llmReasoning). Supported on Sonnet 3.7+, Claude 4 / Sonnet 4.x, etc. If off, you only get normal answer tokens.',
+                    'Turn on to stream Claude internal thinking separately from the answer (SSE event name: llmReasoning). On Sonnet 3.7 through Sonnet 4.6, uses manual extended thinking with Budget Tokens. On Claude Sonnet 5 and Opus 4.7+, uses adaptive thinking when on, or disables thinking when off.',
                 optional: true,
                 additionalParams: true
             },
@@ -102,7 +107,8 @@ class ChatAnthropic_ChatModels implements INode {
                 type: 'number',
                 step: 1,
                 default: 1024,
-                description: 'Maximum number of tokens Claude is allowed use for its internal reasoning process',
+                description:
+                    'Maximum thinking tokens for manual extended thinking (Sonnet 3.7 through Sonnet 4.6). Ignored on Claude Sonnet 5 and Opus 4.7+, which use adaptive thinking instead.',
                 optional: true,
                 additionalParams: true
             },
@@ -176,23 +182,32 @@ class ChatAnthropic_ChatModels implements INode {
 
         const allowImageUploads = nodeData.inputs?.allowImageUploads as boolean
 
+        const omitSamplingParams = rejectsSamplingParams(modelName)
+
         const obj: Partial<AnthropicInput> & BaseLLMParams & { anthropicApiKey?: string } = {
-            temperature: parseFloat(temperature),
             modelName,
             anthropicApiKey,
             streaming: streaming ?? true
         }
 
+        if (!omitSamplingParams) {
+            obj.temperature = parseFloat(temperature)
+        }
+
         if (maxTokens) obj.maxTokens = parseInt(maxTokens, 10)
-        if (topP) obj.topP = parseFloat(topP)
-        if (topK) obj.topK = parseFloat(topK)
+        if (!omitSamplingParams) {
+            if (topP) obj.topP = parseFloat(topP)
+            if (topK) obj.topK = parseFloat(topK)
+        }
         if (cache) obj.cache = cache
-        if (extendedThinking) {
-            obj.thinking = {
-                type: 'enabled',
-                budget_tokens: parseInt(budgetTokens, 10)
+
+        const thinking = buildThinkingConfig(modelName, extendedThinking ?? false, budgetTokens)
+        if (thinking) {
+            // @ts-ignore – adaptive/disabled types added in newer Anthropic API; LangChain types may lag
+            obj.thinking = thinking
+            if (thinking.type === 'enabled') {
+                delete obj.temperature
             }
-            delete obj.temperature
         }
 
         // Collect anthropic-beta header values (comma-separated), de-duplicated

--- a/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.ts
@@ -4,6 +4,7 @@ import { CallbackManagerForLLMRun } from '@langchain/core/callbacks/manager'
 import { type BaseMessage, type MessageContentComplex } from '@langchain/core/messages'
 import { type ChatResult, type ChatGenerationChunk } from '@langchain/core/outputs'
 import { IVisionChatModal, IMultiModalOption } from '../../../src'
+import { rejectsSamplingParams, stripSamplingParams } from './anthropicModelCompat'
 
 const DEFAULT_IMAGE_MODEL = 'claude-3-5-haiku-latest'
 const DEFAULT_IMAGE_MAX_TOKEN = 2048
@@ -58,24 +59,31 @@ export class ChatAnthropic extends LangchainChatAnthropic implements IVisionChat
      * Langchain's ChatAnthropic defaults topP and topK to -1 as "unset" sentinels, but the
      * Anthropic API rejects -1 on newer models (e.g. claude-sonnet-4-6). Additionally, some
      * models reject requests where both temperature and top_p are present simultaneously.
+     * Claude Sonnet 5 and Opus 4.7+ reject any non-default sampling parameters entirely.
      *
      * Rules applied here:
      *  - Strip top_p / top_k when they are -1 (Langchain's unset sentinel).
      *  - If a valid top_p (0–1) is being sent, also strip temperature (mutually exclusive on newer models).
+     *  - Omit all sampling params for Sonnet 5 / Opus 4.7+.
      */
     // @ts-ignore – return type intentionally widened; base class uses a complex intersection type that varies across langchain versions
     invocationParams(options?: this['ParsedCallOptions']): Record<string, unknown> {
         const params = super.invocationParams(options) as Record<string, unknown>
+        const modelName = this.modelName || this.configuredModel
 
-        const topP = params['top_p']
-        const topK = params['top_k']
+        if (rejectsSamplingParams(modelName)) {
+            stripSamplingParams(params)
+        } else {
+            const topP = params['top_p']
+            const topK = params['top_k']
 
-        // Remove sentinel -1 values that Langchain uses to mean "not set"
-        if (topP === -1 || topP === undefined) delete params['top_p']
-        if (topK === -1 || topK === undefined) delete params['top_k']
+            // Remove sentinel -1 values that Langchain uses to mean "not set"
+            if (topP === -1 || topP === undefined) delete params['top_p']
+            if (topK === -1 || topK === undefined) delete params['top_k']
 
-        // If a valid top_p is being sent, temperature must be omitted (mutually exclusive on newer models)
-        if (typeof params['top_p'] === 'number') delete params['temperature']
+            // If a valid top_p is being sent, temperature must be omitted (mutually exclusive on newer models)
+            if (typeof params['top_p'] === 'number') delete params['temperature']
+        }
 
         if (this.promptCaching) {
             // Explicit breakpoint on the tool definitions: tools sit at the front of the prefix

--- a/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.test.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.test.ts
@@ -1,0 +1,57 @@
+import {
+    buildThinkingConfig,
+    rejectsSamplingParams,
+    requiresAdaptiveThinkingApi,
+    stripSamplingParams
+} from './anthropicModelCompat'
+
+describe('anthropicModelCompat', () => {
+    describe('rejectsSamplingParams', () => {
+        it.each([
+            'claude-sonnet-5',
+            'claude-opus-4-8',
+            'claude-opus-4-7',
+            'claude-opus-4-7-20251101'
+        ])('returns true for %s', (model) => {
+            expect(rejectsSamplingParams(model)).toBe(true)
+        })
+
+        it.each([
+            'claude-sonnet-4-6',
+            'claude-sonnet-4-5',
+            'claude-opus-4-6',
+            'claude-3-haiku',
+            'claude-3-5-sonnet-latest'
+        ])('returns false for %s', (model) => {
+            expect(rejectsSamplingParams(model)).toBe(false)
+        })
+    })
+
+    describe('buildThinkingConfig', () => {
+        it('uses adaptive/disabled for Sonnet 5', () => {
+            expect(buildThinkingConfig('claude-sonnet-5', true, '1024')).toEqual({ type: 'adaptive' })
+            expect(buildThinkingConfig('claude-sonnet-5', false, '1024')).toEqual({ type: 'disabled' })
+        })
+
+        it('uses manual extended thinking for older Sonnet models when enabled', () => {
+            expect(buildThinkingConfig('claude-sonnet-4-6', true, '2048')).toEqual({
+                type: 'enabled',
+                budget_tokens: 2048
+            })
+            expect(buildThinkingConfig('claude-sonnet-4-6', false, '2048')).toBeUndefined()
+        })
+    })
+
+    describe('stripSamplingParams', () => {
+        it('removes temperature, top_p, and top_k', () => {
+            const params = { temperature: 0.9, top_p: 0.5, top_k: 40, max_tokens: 1024 }
+            stripSamplingParams(params)
+            expect(params).toEqual({ max_tokens: 1024 })
+        })
+    })
+
+    it('requiresAdaptiveThinkingApi matches rejectsSamplingParams', () => {
+        expect(requiresAdaptiveThinkingApi('claude-sonnet-5')).toBe(true)
+        expect(requiresAdaptiveThinkingApi('claude-sonnet-4-6')).toBe(false)
+    })
+})

--- a/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.ts
@@ -1,0 +1,42 @@
+/**
+ * Anthropic API compatibility helpers for models with breaking behavior changes
+ * (Claude Sonnet 5, Opus 4.7+, etc.).
+ * @see https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
+ */
+
+/** Models that reject non-default temperature, top_p, and top_k. */
+export function rejectsSamplingParams(modelName: string): boolean {
+    const normalized = modelName.trim().toLowerCase()
+    if (normalized === 'claude-sonnet-5') return true
+    if (normalized === 'claude-opus-4-8' || normalized.startsWith('claude-opus-4-8')) return true
+    if (normalized === 'claude-opus-4-7' || normalized.startsWith('claude-opus-4-7')) return true
+    return false
+}
+
+/** Models that removed manual extended thinking (`budget_tokens`); use adaptive/disabled instead. */
+export function requiresAdaptiveThinkingApi(modelName: string): boolean {
+    return rejectsSamplingParams(modelName)
+}
+
+export function stripSamplingParams(params: Record<string, unknown>): void {
+    delete params['temperature']
+    delete params['top_p']
+    delete params['top_k']
+}
+
+export type AnthropicThinkingConfig =
+    | { type: 'enabled'; budget_tokens: number }
+    | { type: 'adaptive' }
+    | { type: 'disabled' }
+
+/** Build the `thinking` payload for a model + Extended Thinking toggle. */
+export function buildThinkingConfig(modelName: string, extendedThinking: boolean, budgetTokens: string): AnthropicThinkingConfig | undefined {
+    if (requiresAdaptiveThinkingApi(modelName)) {
+        return { type: extendedThinking ? 'adaptive' : 'disabled' }
+    }
+    if (!extendedThinking) return undefined
+    return {
+        type: 'enabled',
+        budget_tokens: parseInt(budgetTokens, 10) || 1024
+    }
+}


### PR DESCRIPTION
Register Sonnet 5 in models.json with introductory pricing, and update ChatAnthropic to omit sampling params and use adaptive/disabled thinking for Sonnet 5 and Opus 4.7+ while preserving legacy behavior for older models.