### PR TITLE
Fix Sonnet 5 reasoning stream by requesting summarized thinking display.

### DIFF
--- a/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
@@ -22,7 +22,7 @@ class ChatAnthropic_ChatModels implements INode {
     constructor() {
         this.label = 'ChatAnthropic'
         this.name = 'chatAnthropic'
-        this.version = 9.3
+        this.version = 9.4
         this.type = 'ChatAnthropic'
         this.icon = 'Anthropic.svg'
         this.category = 'Chat Models'
@@ -97,7 +97,7 @@ class ChatAnthropic_ChatModels implements INode {
                 name: 'extendedThinking',
                 type: 'boolean',
                 description:
-                    'Turn on to stream Claude internal thinking separately from the answer (SSE event name: llmReasoning). On Sonnet 3.7 through Sonnet 4.6, uses manual extended thinking with Budget Tokens. On Claude Sonnet 5 and Opus 4.7+, uses adaptive thinking when on, or disables thinking when off.',
+                    'Turn on to stream Claude internal thinking separately from the answer (SSE event name: llmReasoning). On Sonnet 3.7 through Sonnet 4.6, uses manual extended thinking with Budget Tokens. On Claude Sonnet 5 and Opus 4.7+, uses adaptive thinking with summarized display when on, or disables thinking when off.',
                 optional: true,
                 additionalParams: true
             },

--- a/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/FlowiseChatAnthropic.ts
@@ -85,6 +85,11 @@ export class ChatAnthropic extends LangchainChatAnthropic implements IVisionChat
             if (typeof params['top_p'] === 'number') delete params['temperature']
         }
 
+        const thinking = params['thinking'] as { type?: string; display?: string } | undefined
+        if (thinking?.type === 'adaptive' && thinking.display !== 'summarized') {
+            thinking.display = 'summarized'
+        }
+
         if (this.promptCaching) {
             // Explicit breakpoint on the tool definitions: tools sit at the front of the prefix
             // (tools -> system -> messages), so a breakpoint on the last tool caches the (usually

--- a/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.test.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.test.ts
@@ -29,7 +29,10 @@ describe('anthropicModelCompat', () => {
 
     describe('buildThinkingConfig', () => {
         it('uses adaptive/disabled for Sonnet 5', () => {
-            expect(buildThinkingConfig('claude-sonnet-5', true, '1024')).toEqual({ type: 'adaptive' })
+            expect(buildThinkingConfig('claude-sonnet-5', true, '1024')).toEqual({
+                type: 'adaptive',
+                display: 'summarized'
+            })
             expect(buildThinkingConfig('claude-sonnet-5', false, '1024')).toEqual({ type: 'disabled' })
         })
 

--- a/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.ts
@@ -26,13 +26,18 @@ export function stripSamplingParams(params: Record<string, unknown>): void {
 
 export type AnthropicThinkingConfig =
     | { type: 'enabled'; budget_tokens: number }
-    | { type: 'adaptive' }
+    | { type: 'adaptive'; display: 'summarized' }
     | { type: 'disabled' }
 
 /** Build the `thinking` payload for a model + Extended Thinking toggle. */
 export function buildThinkingConfig(modelName: string, extendedThinking: boolean, budgetTokens: string): AnthropicThinkingConfig | undefined {
     if (requiresAdaptiveThinkingApi(modelName)) {
-        return { type: extendedThinking ? 'adaptive' : 'disabled' }
+        if (extendedThinking) {
+            // Sonnet 5 / Opus 4.7+ default to display:"omitted" (no readable thinking in stream).
+            // Flowise Extended Thinking toggle expects llmReasoning SSE — opt in to summarized text.
+            return { type: 'adaptive', display: 'summarized' }
+        }
+        return { type: 'disabled' }
     }
     if (!extendedThinking) return undefined
     return {


### PR DESCRIPTION
Sonnet 5 and Opus 4.7+ omit readable thinking by default; opt in to display:summarized when Extended Thinking is enabled so llmReasoning SSE events receive text again.