### PR TITLE
fix(ChatAnthropic): nest effort under output_config for Anthropic API

### DIFF
--- a/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/ChatAnthropic.ts
@@ -219,9 +219,10 @@ class ChatAnthropic_ChatModels implements INode {
         if (cache) obj.cache = cache
 
         if (effort && supportsEffort(modelName)) {
-            // `effort` is a top-level Anthropic API field not yet modeled in @langchain/anthropic's
-            // AnthropicInput; invocationKwargs is spread last into invocationParams() so it passes through untouched.
-            obj.invocationKwargs = { ...obj.invocationKwargs, effort }
+            // `effort` is nested under `output_config` in the Anthropic API (not a top-level field);
+            // not yet modeled in @langchain/anthropic's AnthropicInput, but invocationKwargs is spread
+            // last into invocationParams() so it passes through untouched.
+            obj.invocationKwargs = { ...obj.invocationKwargs, output_config: { effort } }
         }
 
         const thinking = buildThinkingConfig(modelName, extendedThinking ?? false, budgetTokens)

--- a/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.ts
+++ b/packages/components/nodes/chatmodels/ChatAnthropic/anthropicModelCompat.ts
@@ -29,7 +29,8 @@ export const EFFORT_VALUES = ['low', 'medium', 'high', 'xhigh', 'max'] as const
 export type AnthropicEffort = (typeof EFFORT_VALUES)[number]
 
 /**
- * Models that support the top-level `effort` parameter (tunes intelligence vs. token spend).
+ * Models that support the `effort` parameter (tunes intelligence vs. token spend), sent as
+ * `output_config: { effort }` in the Anthropic API request body.
  * @see https://platform.claude.com/docs/en/build-with-claude/effort
  */
 export function supportsEffort(modelName: string): boolean {


### PR DESCRIPTION
Anthropic's API expects effort as output_config.effort, not a top-level field. Sending it top-level caused a 400 "Extra inputs are not permitted" error.